### PR TITLE
Updating library.json to point at latest

### DIFF
--- a/library.json
+++ b/library.json
@@ -6,8 +6,8 @@
         "name": "F Malpartida",
         "url": "https://bitbucket.org/fmalpartida"
     },
-    "version": "1.2.1",
-    "downloadUrl": "https://bitbucket.org/fmalpartida/new-liquidcrystal/downloads/LiquidCrystal_V1.2.1.zip",
+    "version": "1.3.4",
+    "downloadUrl": "https://bitbucket.org/fmalpartida/new-liquidcrystal/downloads/NewliquidCrystal_1.3.4.zip",
     "include": "LiquidCrystal",
     "exclude": "LiquidCrystal/docs",
     "frameworks": "arduino",


### PR DESCRIPTION
Latest release is 1.3.4 from last year, but based on some merges I'd expect a 1.3.5 soon
